### PR TITLE
Fix for numeric label keys that are created from indexed placeholders

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
@@ -154,12 +154,21 @@ namespace Serilog.Sinks.Grafana.Loki
             {
                 var key = property.Key;
 
+                // If a message template is a composite format string that contains indexed placeholders ({0}, {1} etc),
+                // Serilog turns these placeholders into event properties keyed by numeric strings.
+                // Loki doesn't accept such strings as label keys. Prefix these numeric strings with "param"
+                // to turn them into valid label keys and at the same time denote them as ordinal parameters.
+                if (char.IsDigit(key[0]))
+                {
+                    key = "param" + key;
+                }
+
                 // Some enrichers generates extra quotes and it breaks the payload
                 var value = property.Value.ToString().Replace("\"", string.Empty);
 
                 if (IsAllowedByFilter(key))
                 {
-                    labels.Add(property.Key, value);
+                    labels.Add(key, value);
                 }
             }
 


### PR DESCRIPTION
This is to fix label keys that are created from indexed placeholders in message template (such as "{0}"). Numeric strings are rejected by Loki as label keys. To make such keys compatible, prefix them with alpha characters like "param". This will also indicate that the label corresponds to an ordinal parameter,