### PR TITLE
Created internal timestamp calculated on arrival of log in queue (preventing Out of Order)

### DIFF
--- a/sample/Serilog.Sinks.Grafana.Loki.Sample/Program.cs
+++ b/sample/Serilog.Sinks.Grafana.Loki.Sample/Program.cs
@@ -23,7 +23,8 @@ namespace Serilog.Sinks.Grafana.Loki.Sample
                     new List<LokiLabel> { new() { Key = "app", Value = "console" } },
                     credentials: null,
                     outputTemplate: OutputTemplate,
-                    createLevelLabel: true)
+                    createLevelLabel: true,
+                    useInternalTimestamp: false)
                 .CreateLogger();
 
             Log.Debug("This is a debug message");

--- a/sample/Serilog.Sinks.Grafana.Loki.SampleWebApp/appsettings.json
+++ b/sample/Serilog.Sinks.Grafana.Loki.SampleWebApp/appsettings.json
@@ -32,7 +32,8 @@
             }
           ],
           "outputTemplate": "[{ThreadId}] [{TraceId:l}] {Message}{NewLine}{Exception}",
-          "createLevelLabel": true
+          "createLevelLabel": true,
+          "useInternalTimestamp": true
         }
       }
     ]

--- a/src/Serilog.Sinks.Grafana.Loki/ILokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/ILokiBatchFormatter.cs
@@ -8,6 +8,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Serilog.Events;
@@ -32,6 +33,6 @@ namespace Serilog.Sinks.Grafana.Loki
         /// <param name="output">
         /// The payload to send over the network.
         /// </param>
-        void Format(IReadOnlyCollection<LogEvent> logEvents, ITextFormatter formatter, TextWriter output);
+        void Format(IReadOnlyCollection<(LogEvent Event, DateTimeOffset Timestamp)> logEvents, ITextFormatter formatter, TextWriter output);
     }
 }

--- a/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
@@ -83,6 +83,9 @@ namespace Serilog.Sinks.Grafana.Loki
         /// Should level label be created. Default value is false
         /// The level label always won't be created while using <see cref="ILabelAwareTextFormatter"/>
         /// </param>
+        /// <param name="useInternalTimestamp">
+        /// Should use internal timestamp instead of application timestamp to use as Log Timestamp.
+        /// </param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public static LoggerConfiguration GrafanaLoki(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -98,7 +101,8 @@ namespace Serilog.Sinks.Grafana.Loki
             TimeSpan? period = null,
             ITextFormatter? textFormatter = null,
             ILokiHttpClient? httpClient = null,
-            bool createLevelLabel = false)
+            bool createLevelLabel = false,
+            bool useInternalTimestamp = false)
         {
             if (sinkConfiguration == null)
             {
@@ -106,7 +110,7 @@ namespace Serilog.Sinks.Grafana.Loki
             }
 
             createLevelLabel = createLevelLabel && textFormatter is not ILabelAwareTextFormatter {ExcludeLevelLabel: true};
-            var batchFormatter = new LokiBatchFormatter(labels, filtrationMode, filtrationLabels, createLevelLabel);
+            var batchFormatter = new LokiBatchFormatter(labels, filtrationMode, filtrationLabels, createLevelLabel, useInternalTimestamp);
 
             period ??= TimeSpan.FromSeconds(1);
             textFormatter ??= new MessageTemplateTextFormatter(outputTemplate);
@@ -121,7 +125,8 @@ namespace Serilog.Sinks.Grafana.Loki
                 period.Value,
                 textFormatter,
                 batchFormatter,
-                httpClient);
+                httpClient,
+                useInternalTimestamp);
 
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.Grafana.Loki/LokiSink.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiSink.cs
@@ -33,7 +33,8 @@ namespace Serilog.Sinks.Grafana.Loki
         private readonly object _syncRoot = new();
         private readonly PortableTimer _timer;
         private readonly BoundedQueue<LogEvent> _queue;
-        private readonly Queue<LogEvent> _waitingBatch = new();
+        private readonly bool _useInternalTimestamp;
+        private readonly Queue<(LogEvent Event, DateTimeOffset Timestamp)> _waitingBatch = new();
 
         private bool _isDisposed;
 
@@ -44,7 +45,8 @@ namespace Serilog.Sinks.Grafana.Loki
             TimeSpan period,
             ITextFormatter textFormatter,
             ILokiBatchFormatter batchFormatter,
-            ILokiHttpClient httpClient)
+            ILokiHttpClient httpClient,
+            bool useInternalTimestamp)
         {
             _requestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
             _batchPostingLimit = batchPostingLimit;
@@ -55,6 +57,7 @@ namespace Serilog.Sinks.Grafana.Loki
             _connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
             _timer = new PortableTimer(OnTick);
             _queue = new BoundedQueue<LogEvent>(queueLimit);
+            _useInternalTimestamp = useInternalTimestamp;
 
             SetTimer();
         }
@@ -99,7 +102,7 @@ namespace Serilog.Sinks.Grafana.Loki
                 {
                     while (_waitingBatch.Count < _batchPostingLimit && _queue.TryDequeue(out var next))
                     {
-                        _waitingBatch.Enqueue(next!);
+                        _waitingBatch.Enqueue(((LogEvent Event, DateTimeOffset Timestamp))(next!));
                     }
 
                     batchWasFull = _waitingBatch.Count >= _batchPostingLimit;

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/InfrastructureTests/BoundedQueueTests.cs
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/InfrastructureTests/BoundedQueueTests.cs
@@ -36,9 +36,9 @@ namespace Serilog.Sinks.Grafana.Loki.Tests.InfrastructureTests
             dequeueResult2.ShouldBeTrue();
             dequeueResult3.ShouldBeTrue();
 
-            dequeueItem1.ShouldBe(1);
-            dequeueItem2.ShouldBe(2);
-            dequeueItem3.ShouldBe(3);
+            dequeueItem1!.Value.Event.ShouldBe(1);
+            dequeueItem2!.Value.Event.ShouldBe(2);
+            dequeueItem3!.Value.Event.ShouldBe(3);
         }
 
         [Fact]


### PR DESCRIPTION
In some situations, multithread applications can write logs in an "out of order" manner.

The sink object is a singleton and the source queue is synchronized, so it's safe to use the current timestamp at [ILogEventSink.Emit](https://github.com/serilog-contrib/serilog-sinks-grafana-loki/blob/53aa24306a197028ab8768ddce5da5004fe815b4/src/Serilog.Sinks.Grafana.Loki/LokiSink.cs#L62)

Resolves #49 

