### PR TITLE
Fix Json Formatting for AggregateExceptions

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.cs
@@ -165,7 +165,7 @@ namespace Serilog.Sinks.Grafana.Loki
                 var count = aggregateException.InnerExceptions.Count;
                 for (var i = 0; i < count; i++)
                 {
-                    var isLast = i == count;
+                    var isLast = i == count - 1;
                     SerializeException(output, aggregateException.InnerExceptions[i], level + 1);
                     if (!isLast)
                     {

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/IntegrationTests/LokiJsonTextFormatterRequestPayloadTests.cs
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/IntegrationTests/LokiJsonTextFormatterRequestPayloadTests.cs
@@ -180,7 +180,7 @@ namespace Serilog.Sinks.Grafana.Loki.Tests.IntegrationTests
                         .Replace(s, "\"[0-9]{19}\"", "\"<unixepochinnanoseconds>\"");
                     return Regex.Replace(
                         s,
-                        @"(?<=\\u0022StackTrace)(.*?)(?=}})",
+                        @"(?<=\\u0022StackTrace)(.*?)}\](?=}})",
                         @"<stack-trace>");
                 });
             });


### PR DESCRIPTION
AggregateExceptions were serialized with a trailing comma which resulted in errors while trying to process the JSON in grafana.