### PR TITLE
Add parameters to LokiJsonTextFormatter

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.cs
@@ -32,13 +32,17 @@ namespace Serilog.Sinks.Grafana.Loki
         /// <summary>
         /// Initializes a new instance of the <see cref="LokiJsonTextFormatter"/> class.
         /// </summary>
-        public LokiJsonTextFormatter()
+        /// <param name="excludeLevelLabel">
+        /// If set, the level label will be excluded from the set of labels sent to Loki.
+        /// </param>
+        public LokiJsonTextFormatter(bool excludeLevelLabel = true)
         {
+            ExcludeLevelLabel = excludeLevelLabel;
             _valueFormatter = new JsonValueFormatter("$type");
         }
 
         /// <inheritdoc/>
-        public bool ExcludeLevelLabel => true;
+        public bool ExcludeLevelLabel { get; }
 
         /// <summary>
         /// Format the log event into the output.


### PR DESCRIPTION
This adds three parameters to `LokiJsonTextFormatter`:

- `excludeLevelLabel` - If set, the level label will be excluded from the set of labels sent to Loki. This addresses the issue in #74 by making the exclusion of the level label configurable.
- `excludeTemplate` - If set, the message template will not be included in the JSON rendering of each event.
- `excludeRenderings` - If set, the rendered tokens will not be included in the JSON rendering of each event.

The second and third option were added to reduce the size of each message if they aren't desired.