### PR TITLE
Allowing the json formatted Loki message to still include a level as a Label.

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.cs
@@ -32,13 +32,17 @@ namespace Serilog.Sinks.Grafana.Loki
         /// <summary>
         /// Initializes a new instance of the <see cref="LokiJsonTextFormatter"/> class.
         /// </summary>
-        public LokiJsonTextFormatter()
+        /// <param name="excludeLevelLabel">
+        /// If set to true, this will exclude the level from being written as a label. Instead it will be contained in the json message only.
+        /// </param>
+        public LokiJsonTextFormatter(bool excludeLevelLabel = true)
         {
             _valueFormatter = new JsonValueFormatter("$type");
+            ExcludeLevelLabel = excludeLevelLabel;
         }
 
         /// <inheritdoc/>
-        public bool ExcludeLevelLabel => true;
+        public bool ExcludeLevelLabel { get; private set; }
 
         /// <summary>
         /// Format the log event into the output.


### PR DESCRIPTION
In my use case, I still want the level information to be a high-level label instead of being part of the json body. This way it's indexed directly and doesn't require parsing the json of all messages just to filter by it.

This simple PR exposes the already existing flag ExcludeLevelLabel as a constructor property.