### PR TITLE
Add opt out to filtering the properties list when using propertiesAsLabels

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
@@ -73,6 +73,9 @@ public static class LoggerConfigurationLokiExtensions
     /// <param name="useInternalTimestamp">
     /// Should use internal sink timestamp instead of application one to use as log timestamp.
     /// </param>
+    /// <param name="leavePropertiesIntact">
+    /// Leaves the list of properties intact after extracting the labels specified in propertiesAsLabels.
+    /// </param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     public static LoggerConfiguration GrafanaLoki(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -87,7 +90,8 @@ public static class LoggerConfigurationLokiExtensions
         ITextFormatter? textFormatter = null,
         ILokiHttpClient? httpClient = null,
         IReservedPropertyRenamingStrategy? reservedPropertyRenamingStrategy = null,
-        bool useInternalTimestamp = false)
+        bool useInternalTimestamp = false,
+        bool leavePropertiesIntact = false)
     {
         if (sinkConfiguration == null)
         {
@@ -105,7 +109,8 @@ public static class LoggerConfigurationLokiExtensions
             reservedPropertyRenamingStrategy,
             labels,
             propertiesAsLabels,
-            useInternalTimestamp);
+            useInternalTimestamp,
+            leavePropertiesIntact);
 
         var sink = new LokiSink(
             LokiRoutesBuilder.BuildLogsEntriesRoute(uri),

--- a/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
@@ -54,6 +54,9 @@ internal class LokiBatchFormatter : ILokiBatchFormatter
     /// <param name="useInternalTimestamp">
     /// Compute internal timestamp
     /// </param>
+    /// <param name="leavePropertiesIntact">
+    /// Leave the list of properties intact after extracting the labels specified in propertiesAsLabels.
+    /// </param>
     public LokiBatchFormatter(
         IReservedPropertyRenamingStrategy renamingStrategy,
         IEnumerable<LokiLabel>? globalLabels = null,

--- a/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
@@ -34,6 +34,8 @@ internal class LokiBatchFormatter : ILokiBatchFormatter
     private readonly IEnumerable<LokiLabel> _globalLabels;
     private readonly IReservedPropertyRenamingStrategy _renamingStrategy;
     private readonly IEnumerable<string> _propertiesAsLabels;
+
+    private readonly bool _leavePropertiesIntact;
     private readonly bool _useInternalTimestamp;
 
     /// <summary>
@@ -56,12 +58,14 @@ internal class LokiBatchFormatter : ILokiBatchFormatter
         IReservedPropertyRenamingStrategy renamingStrategy,
         IEnumerable<LokiLabel>? globalLabels = null,
         IEnumerable<string>? propertiesAsLabels = null,
-        bool useInternalTimestamp = false)
+        bool useInternalTimestamp = false,
+        bool leavePropertiesIntact = false)
     {
         _renamingStrategy = renamingStrategy;
         _globalLabels = globalLabels ?? Enumerable.Empty<LokiLabel>();
         _propertiesAsLabels = propertiesAsLabels ?? Enumerable.Empty<string>();
         _useInternalTimestamp = useInternalTimestamp;
+        _leavePropertiesIntact = leavePropertiesIntact;
     }
 
     /// <summary>
@@ -214,6 +218,6 @@ internal class LokiBatchFormatter : ILokiBatchFormatter
         }
 
         return (labels,
-            lokiLogEvent.CopyWithProperties(remainingProperties));
+            lokiLogEvent.CopyWithProperties(_leavePropertiesIntact ? properties : remainingProperties));
     }
 }


### PR DESCRIPTION
Workaround for #138

For our use case having the 3 or 4 labels we extract also in the JSON body is completely fine and it also repairs the formatting, which for us is more important. So an opt-out feature is very useful.