### PR TITLE
Increased precision of sended timestamp on .net 7.0 and greater

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/Utils/DateTimeOffsetExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Utils/DateTimeOffsetExtensions.cs
@@ -12,6 +12,14 @@ namespace Serilog.Sinks.Grafana.Loki.Utils;
 
 internal static class DateTimeOffsetExtensions
 {
+    #if NET7_0_OR_GREATER
+    internal static string ToUnixNanosecondsString(this DateTimeOffset offset) =>
+        ((offset.ToUnixTimeMilliseconds() * 1000000) +
+         (offset.Microsecond * 1000) +
+         offset.Nanosecond).ToString();
+    #else
     internal static string ToUnixNanosecondsString(this DateTimeOffset offset) =>
         (offset.ToUnixTimeMilliseconds() * 1000000).ToString();
+    #endif
+
 }

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/UtilsTests/DateTimeOffsetExtensionsTests.cs
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/UtilsTests/DateTimeOffsetExtensionsTests.cs
@@ -25,4 +25,17 @@ public class DateTimeOffsetExtensionsTests
 
         result.ShouldBe("1621944000000000000");
     }
+
+#if NET7_0_OR_GREATER
+    [Fact]
+    public void DateTimeNanosecondsOffsetShouldBeConvertedCorrectly()
+    {
+        var dateTimeOffset =
+            new DateTimeOffset(2021, 05, 25, 12, 00, 00, 777, 888, TimeSpan.Zero).AddMicroseconds(0.999); // There is no other way to set nanoseconds
+
+        var result = dateTimeOffset.ToUnixNanosecondsString();
+
+        result.ShouldBe("1621944000777888900");
+    }
+#endif
 }


### PR DESCRIPTION
This will fix #208 