### PR TITLE
Add nanosecond support for timestamps for versions prior to .NET 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ macOS-latest, ubuntu-latest, windows-latest ]
-    name: ${{ matrix.runs-on }}
-    runs-on: ${{ matrix.runs-on }}
+        os: [ macOS-latest, ubuntu-latest, windows-latest ]
+        dotnet: [ '5.x', '6.x', '7.x']
+    name: ${{ matrix.os }} - ${{ matrix.dotnet }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +31,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.0.0
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ matrix.dotnet }}
 
       - run: dotnet --info
 

--- a/src/Serilog.Sinks.Grafana.Loki/Utils/DateTimeOffsetExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Utils/DateTimeOffsetExtensions.cs
@@ -12,14 +12,9 @@ namespace Serilog.Sinks.Grafana.Loki.Utils;
 
 internal static class DateTimeOffsetExtensions
 {
-    #if NET7_0_OR_GREATER
-    internal static string ToUnixNanosecondsString(this DateTimeOffset offset) =>
-        ((offset.ToUnixTimeMilliseconds() * 1000000) +
-         (offset.Microsecond * 1000) +
-         offset.Nanosecond).ToString();
-    #else
-    internal static string ToUnixNanosecondsString(this DateTimeOffset offset) =>
-        (offset.ToUnixTimeMilliseconds() * 1000000).ToString();
-    #endif
+    private const long NanosecondsPerTick = 100;
+    private static readonly DateTimeOffset UnixEpoch = new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
+    internal static string ToUnixNanosecondsString(this DateTimeOffset offset) =>
+        ((offset - UnixEpoch).Ticks * NanosecondsPerTick).ToString();
 }

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/Serilog.Sinks.Grafana.Loki.Tests.csproj
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/Serilog.Sinks.Grafana.Loki.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/UtilsTests/DateTimeOffsetExtensionsTests.cs
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/UtilsTests/DateTimeOffsetExtensionsTests.cs
@@ -6,6 +6,7 @@ namespace Serilog.Sinks.Grafana.Loki.Tests.UtilsTests;
 
 public class DateTimeOffsetExtensionsTests
 {
+    #if NET7_0_OR_GREATER
     [Fact]
     public void UnixEpochShouldBeConvertedCorrectly()
     {
@@ -17,25 +18,29 @@ public class DateTimeOffsetExtensionsTests
     }
 
     [Fact]
-    public void DateTimeOffsetShouldBeConvertedCorrectly()
-    {
-        var dateTimeOffset = new DateTimeOffset(2021, 05, 25, 12, 00, 00, TimeSpan.Zero);
-
-        var result = dateTimeOffset.ToUnixNanosecondsString();
-
-        result.ShouldBe("1621944000000000000");
-    }
-
-#if NET7_0_OR_GREATER
-    [Fact]
     public void DateTimeNanosecondsOffsetShouldBeConvertedCorrectly()
     {
-        var dateTimeOffset =
-            new DateTimeOffset(2021, 05, 25, 12, 00, 00, 777, 888, TimeSpan.Zero).AddMicroseconds(0.999); // There is no other way to set nanoseconds
+        var dateTimeOffset = new DateTimeOffset(2021, 05, 25, 12, 00, 00, 777, 888, TimeSpan.Zero).AddMicroseconds(0.999); // There is no other way to set nanoseconds
 
         var result = dateTimeOffset.ToUnixNanosecondsString();
 
         result.ShouldBe("1621944000777888900");
     }
-#endif
+
+    #else
+    [Fact]
+    public void DateTimeOffsetShouldBeConvertedCorrectly()
+    {
+        const long nanosecondsPerTick = 100;
+
+        var ticks = new DateTimeOffset(2021, 05, 25, 12, 00, 00, TimeSpan.Zero).Ticks;
+        ticks += 777888999 / nanosecondsPerTick;
+
+        var dateTimeOffset = new DateTimeOffset(ticks, TimeSpan.Zero);
+
+        var result = dateTimeOffset.ToUnixNanosecondsString();
+
+        result.ShouldBe("1621944000777888900");
+    }
+    #endif
 }


### PR DESCRIPTION
Closes #248 