### PR TITLE
Add output format option.

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
@@ -81,6 +81,9 @@ public static class LoggerConfigurationLokiExtensions
     /// <param name="leavePropertiesIntact">
     /// Leaves the list of properties intact after extracting the labels specified in propertiesAsLabels.
     /// </param>
+    /// <param name="messageTemplate">
+    /// The message template to use when rendering the log event's `Message` field.
+    /// </param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     public static LoggerConfiguration GrafanaLoki(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -97,7 +100,8 @@ public static class LoggerConfigurationLokiExtensions
         ILokiHttpClient? httpClient = null,
         IReservedPropertyRenamingStrategy? reservedPropertyRenamingStrategy = null,
         bool useInternalTimestamp = false,
-        bool leavePropertiesIntact = false)
+        bool leavePropertiesIntact = false,
+        string? messageTemplate = null)
     {
         if (sinkConfiguration == null)
         {
@@ -106,7 +110,7 @@ public static class LoggerConfigurationLokiExtensions
 
         reservedPropertyRenamingStrategy ??= new DefaultReservedPropertyRenamingStrategy();
         period ??= TimeSpan.FromSeconds(1);
-        textFormatter ??= new LokiJsonTextFormatter(reservedPropertyRenamingStrategy);
+        textFormatter ??= new LokiJsonTextFormatter(reservedPropertyRenamingStrategy, messageTemplate);
         httpClient ??= new LokiHttpClient();
 
         httpClient.SetCredentials(credentials);

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/LokiJsonTextFormatterTests.cs
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/LokiJsonTextFormatterTests.cs
@@ -1,0 +1,31 @@
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.Grafana.Loki.Utils;
+using Shouldly;
+using Xunit;
+
+namespace Serilog.Sinks.Grafana.Loki.Tests;
+
+public class LokiJsonTextFormatterTests
+{
+    [Theory]
+    [InlineData(null, "Log {Token}", "Test", "{\"Message\":\"Log \\\"Test\\\"\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"Test\"}")]
+    [InlineData("{Message:j}", "Log {Token}", "Test", "{\"Message\":\"Log \\\"Test\\\"\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"Test\"}")]
+    [InlineData("{Message:l}", "Log {Token}", "Test", "{\"Message\":\"Log Test\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"Test\"}")]
+    [InlineData(null, "Log {Token}", "{ \"Value\": \"Test\" }", "{\"Message\":\"Log \\\"{ \\\\\\\"Value\\\\\\\": \\\\\\\"Test\\\\\\\" }\\\"\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"{ \\\"Value\\\": \\\"Test\\\" }\"}")]
+    [InlineData("{Message:j}", "Log {Token}", "{ \"Value\": \"Test\" }", "{\"Message\":\"Log \\\"{ \\\\\\\"Value\\\\\\\": \\\\\\\"Test\\\\\\\" }\\\"\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"{ \\\"Value\\\": \\\"Test\\\" }\"}")]
+    [InlineData("{Message:l}", "Log {Token}", "{ \"Value\": \"Test\" }", "{\"Message\":\"Log { \\\"Value\\\": \\\"Test\\\" }\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"{ \\\"Value\\\": \\\"Test\\\" }\"}")]
+    public void ShouldRenderCorrectMessage(string? outputTemplate, string messageTemplate, string property, string expected)
+    {
+        var formatter = new LokiJsonTextFormatter(outputTemplate);
+        var parser = new MessageTemplateParser();
+        var msgTemplate = parser.Parse(messageTemplate);
+        var properties = new List<LogEventProperty> { new LogEventProperty("Token", new ScalarValue(property)) };
+        var logEvent = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null, msgTemplate, properties);
+
+        var output = new StringWriter();
+        formatter.Format(logEvent, output);
+
+        output.ToString().ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
Most libraries that output to text sinks have the ability to format the message. See https://github.com/serilog/serilog/wiki/Formatting-Output#formatting-plain-text. This adds the ability to specify the format of the message written to Loki.

The big feature I'm looking for here is the ability to write messages using the `l` format specifier so all of my properties aren't wrapped in quotes. There are other ways to implement this that don't include the full format options that you need in plain text sinks, but this seemed like the most flexible approach.

The new feature should be backward compatible.