### PR TITLE
Add `usingStringLiteralFormat` Option

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
@@ -81,6 +81,9 @@ public static class LoggerConfigurationLokiExtensions
     /// <param name="leavePropertiesIntact">
     /// Leaves the list of properties intact after extracting the labels specified in propertiesAsLabels.
     /// </param>
+    /// <param name="useStringLiteralFormat">
+    /// When true, the `Message` property of the log event will be rendered without quotes wrapping all string properties.
+    /// </param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     public static LoggerConfiguration GrafanaLoki(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -97,7 +100,8 @@ public static class LoggerConfigurationLokiExtensions
         ILokiHttpClient? httpClient = null,
         IReservedPropertyRenamingStrategy? reservedPropertyRenamingStrategy = null,
         bool useInternalTimestamp = false,
-        bool leavePropertiesIntact = false)
+        bool leavePropertiesIntact = false,
+        bool useStringLiteralFormat = false)
     {
         if (sinkConfiguration == null)
         {
@@ -106,7 +110,7 @@ public static class LoggerConfigurationLokiExtensions
 
         reservedPropertyRenamingStrategy ??= new DefaultReservedPropertyRenamingStrategy();
         period ??= TimeSpan.FromSeconds(1);
-        textFormatter ??= new LokiJsonTextFormatter(reservedPropertyRenamingStrategy);
+        textFormatter ??= new LokiJsonTextFormatter(reservedPropertyRenamingStrategy, useStringLiteralFormat);
         httpClient ??= new LokiHttpClient();
 
         httpClient.SetCredentials(credentials);

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/LokiJsonTextFormatterTests.cs
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/LokiJsonTextFormatterTests.cs
@@ -1,0 +1,27 @@
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.Grafana.Loki.Utils;
+using Shouldly;
+using Xunit;
+
+namespace Serilog.Sinks.Grafana.Loki.Tests;
+
+public class LokiJsonTextFormatterTests
+{
+    [Theory]
+    [InlineData(false, "Log {Token}", "Test", "{\"Message\":\"Log \\\"Test\\\"\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"Test\"}")]
+    [InlineData(true, "Log {Token}", "Test", "{\"Message\":\"Log Test\",\"MessageTemplate\":\"Log {Token}\",\"Token\":\"Test\"}")]
+    public void ShouldRenderMessageWithCorrectFormatting(bool useStringLiteralFormat, string messageTemplate, string property, string expected)
+    {
+        var formatter = new LokiJsonTextFormatter(useStringLiteralFormat);
+        var parser = new MessageTemplateParser();
+        var msgTemplate = parser.Parse(messageTemplate);
+        var properties = new List<LogEventProperty> { new LogEventProperty("Token", new ScalarValue(property)) };
+        var logEvent = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null, msgTemplate, properties);
+
+        var output = new StringWriter();
+        formatter.Format(logEvent, output);
+
+        output.ToString().ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
Most sinks have this option enabled by default. This allows consumers who prefer the literal string format to enable it for all log messages. This is the equivalent of specifying the `:l` format specifier on all properties. See https://github.com/serilog/serilog/wiki/Formatting-Output#formatting-plain-text.