### PR TITLE
Add support for Trace ID and Span ID being sent to Loki

### DIFF
--- a/sample/Serilog.Sinks.Grafana.Loki.Sample/Serilog.Sinks.Grafana.Loki.Sample.csproj
+++ b/sample/Serilog.Sinks.Grafana.Loki.Sample/Serilog.Sinks.Grafana.Loki.Sample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/sample/Serilog.Sinks.Grafana.Loki.SampleWebApp/Serilog.Sinks.Grafana.Loki.SampleWebApp.csproj
+++ b/sample/Serilog.Sinks.Grafana.Loki.SampleWebApp/Serilog.Sinks.Grafana.Loki.SampleWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiBatchFormatter.cs
@@ -171,12 +171,26 @@ internal class LokiBatchFormatter : ILokiBatchFormatter
 
         var logEvent = lokiLogEvent.LogEvent;
         var timestamp = logEvent.Timestamp;
+        var traceId = logEvent.TraceId;
+        var spanId = logEvent.SpanId;
 
         if (_useInternalTimestamp)
         {
             logEvent.AddPropertyIfAbsent(
                 new LogEventProperty("Timestamp", new ScalarValue(timestamp)));
             timestamp = lokiLogEvent.InternalTimestamp;
+        }
+
+        if (traceId.HasValue)
+        {
+            logEvent.AddPropertyIfAbsent(
+                new LogEventProperty("TraceId", new ScalarValue(traceId)));
+        }
+
+        if (spanId.HasValue)
+        {
+            logEvent.AddPropertyIfAbsent(
+                new LogEventProperty("SpanId", new ScalarValue(spanId)));
         }
 
         formatter.Format(logEvent, buffer);

--- a/src/Serilog.Sinks.Grafana.Loki/Models/LokiLogEvent.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Models/LokiLogEvent.cs
@@ -53,7 +53,9 @@ public class LokiLogEvent
             LogEvent.Level,
             LogEvent.Exception,
             LogEvent.MessageTemplate,
-            properties.Select(p => new LogEventProperty(p.Key, p.Value)));
+            properties.Select(p => new LogEventProperty(p.Key, p.Value)),
+            LogEvent.TraceId ?? default,
+            LogEvent.SpanId ?? default);
 
         return this;
     }

--- a/src/Serilog.Sinks.Grafana.Loki/Serilog.Sinks.Grafana.Loki.csproj
+++ b/src/Serilog.Sinks.Grafana.Loki/Serilog.Sinks.Grafana.Loki.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>Serilog.Sinks.Grafana.Loki</AssemblyName>
         <Description>A Serilog sink sending log events to Grafana Loki</Description>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <!--SourceLink -->
@@ -24,8 +24,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="2.12.0" />
-        <PackageReference Include="System.Text.Json" Version="4.7.0" />
+        <PackageReference Include="Serilog" Version="3.1.1" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Serilog.Sinks.Grafana.Loki.Tests/Serilog.Sinks.Grafana.Loki.Tests.csproj
+++ b/test/Serilog.Sinks.Grafana.Loki.Tests/Serilog.Sinks.Grafana.Loki.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
This pull request aims to address supporting the Trace Id and Span Id fields mentioned in #233 

This bumps the minimum Serilog version to 3.1 (from 2.12) and the minimum .NET version to 6 (from 5). As such, this is a breaking change for version 9.