### PR TITLE
Add JsonSerializerContext support

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/Models/LokiBatch.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Models/LokiBatch.cs
@@ -28,5 +28,5 @@ internal class LokiBatch
         return stream;
     }
 
-    public string Serialize() => JsonSerializer.Serialize(this);
+    public string Serialize() => JsonSerializer.Serialize(this, LokiSerializationContext.Default.LokiBatch);
 }

--- a/src/Serilog.Sinks.Grafana.Loki/Models/LokiSerializationContext.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Models/LokiSerializationContext.cs
@@ -1,0 +1,18 @@
+// Copyright 2020-2022 Mykhailo Shevchuk & Contributors
+//
+// Licensed under the MIT license;
+// you may not use this file except in compliance with the License.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace Serilog.Sinks.Grafana.Loki.Models;
+
+[JsonSerializable(typeof(LokiBatch))]
+internal sealed partial class LokiSerializationContext : JsonSerializerContext
+{
+}

--- a/src/Serilog.Sinks.Grafana.Loki/Serilog.Sinks.Grafana.Loki.csproj
+++ b/src/Serilog.Sinks.Grafana.Loki/Serilog.Sinks.Grafana.Loki.csproj
@@ -25,7 +25,8 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog" Version="2.12.0" />
-        <PackageReference Include="System.Text.Json" Version="4.7.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5"
+                          Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net5.0'" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull aim to solve an issue in `GrafanaLoki` where the sink fails to serialize the `LokiBatch` object when reflection-based JSON serialization is disabled in .NET 8.0+ (i.e., when `JsonSerializerIsReflectionEnabledByDefault` is set to `false`). The problem originates in the `LokiBatch.cs` file, where `JsonSerializer.Serialize` lacks proper `JsonTypeInfo` metadata for reflection-free serialization.

Fixes #297 