### PR TITLE
Add support for structured metadata in logs

### DIFF
--- a/sample/Serilog.Sinks.Grafana.Loki.SampleWebApp/appsettings.json
+++ b/sample/Serilog.Sinks.Grafana.Loki.SampleWebApp/appsettings.json
@@ -33,6 +33,10 @@
           ],
           "propertiesAsLabels": [
             "app"
+          ],
+          "propertiesAsStructuredMetadata": [
+            "RequestId",
+            "RequestPath"
           ]
         }
       }

--- a/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/LoggerConfigurationLokiExtensions.cs
@@ -44,6 +44,10 @@ public static class LoggerConfigurationLokiExtensions
     /// <param name="propertiesAsLabels">
     /// The list of properties, which would be mapped to the labels.
     /// </param>
+    /// <param name="propertiesAsStructuredMetadata">
+    /// The list of properties, which would be mapped to structured metadata.
+    /// See <a href="https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs">docs</a>.
+    /// </param>
     /// <param name="credentials">
     /// Auth <see cref="LokiCredentials"/>.
     /// </param>
@@ -81,12 +85,16 @@ public static class LoggerConfigurationLokiExtensions
     /// <param name="leavePropertiesIntact">
     /// Leaves the list of properties intact after extracting the labels specified in propertiesAsLabels.
     /// </param>
+    /// <param name="leaveStructuredMetadataPropertiesIntact">
+    /// Leaves the list of properties intact after extracting the structured metadata specified in propertiesAsStructuredMetadata.
+    /// </param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     public static LoggerConfiguration GrafanaLoki(
         this LoggerSinkConfiguration sinkConfiguration,
         string uri,
         IEnumerable<LokiLabel>? labels = null,
         IEnumerable<string>? propertiesAsLabels = null,
+        IEnumerable<string>? propertiesAsStructuredMetadata = null,
         LokiCredentials? credentials = null,
         string? tenant = null,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -97,7 +105,8 @@ public static class LoggerConfigurationLokiExtensions
         ILokiHttpClient? httpClient = null,
         IReservedPropertyRenamingStrategy? reservedPropertyRenamingStrategy = null,
         bool useInternalTimestamp = false,
-        bool leavePropertiesIntact = false)
+        bool leavePropertiesIntact = false,
+        bool leaveStructuredMetadataPropertiesIntact = false)
     {
         if (sinkConfiguration == null)
         {
@@ -116,8 +125,10 @@ public static class LoggerConfigurationLokiExtensions
             reservedPropertyRenamingStrategy,
             labels,
             propertiesAsLabels,
+            propertiesAsStructuredMetadata,
             useInternalTimestamp,
-            leavePropertiesIntact);
+            leavePropertiesIntact,
+            leaveStructuredMetadataPropertiesIntact);
 
         var sink = new LokiSink(
             LokiRoutesBuilder.BuildLogsEntriesRoute(uri),

--- a/src/Serilog.Sinks.Grafana.Loki/Models/LokiSerializationContext.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Models/LokiSerializationContext.cs
@@ -13,6 +13,9 @@ using System.Text.Json.Serialization;
 namespace Serilog.Sinks.Grafana.Loki.Models;
 
 [JsonSerializable(typeof(LokiBatch))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(object[]))]
+[JsonSerializable(typeof(string))]
 internal sealed partial class LokiSerializationContext : JsonSerializerContext
 {
 }

--- a/src/Serilog.Sinks.Grafana.Loki/Models/LokiStream.cs
+++ b/src/Serilog.Sinks.Grafana.Loki/Models/LokiStream.cs
@@ -19,7 +19,7 @@ internal class LokiStream
     public Dictionary<string, string> Labels { get; } = new();
 
     [JsonPropertyName("values")]
-    public IList<IList<string>> Entries { get; set; } = new List<IList<string>>();
+    public IList<IList<object>> Entries { get; set; } = new List<IList<object>>();
 
     public void AddLabel(string key, string value)
     {
@@ -28,6 +28,17 @@ internal class LokiStream
 
     public void AddEntry(DateTimeOffset timestamp, string entry)
     {
-        Entries.Add(new[] {timestamp.ToUnixNanosecondsString(), entry});
+        Entries.Add(new object[] {timestamp.ToUnixNanosecondsString(), entry});
+    }
+
+    public void AddEntry(DateTimeOffset timestamp, string entry, Dictionary<string, string>? structuredMetadata)
+    {
+        if (structuredMetadata == null || structuredMetadata.Count == 0)
+        {
+            AddEntry(timestamp, entry);
+            return;
+        }
+
+        Entries.Add(new object[] {timestamp.ToUnixNanosecondsString(), entry, structuredMetadata});
     }
 }


### PR DESCRIPTION
- Introduced `propertiesAsStructuredMetadata` to extract high-cardinality data as structured metadata.
- Enhanced `LokiBatchFormatter` and Loki serialization model to handle structured metadata.
- Updated documentation and examples for structured metadata integration.
- Adjusted tests to verify proper metadata serialization behavior.