### PR TITLE
Use relaxed JSON escaping for log bodies

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/Infrastructure/JsonWriterDefaults.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/Infrastructure/JsonWriterDefaults.fs
@@ -1,0 +1,36 @@
+// Copyright 2020-2026 Mykhailo Shevchuk & Contributors
+//
+// Licensed under the MIT license;
+// you may not use this file except in compliance with the License.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See LICENSE file in the project root for full license information.
+
+namespace Serilog.Sinks.Grafana.Loki.Infrastructure
+
+open System.Buffers
+open System.Text.Encodings.Web
+open System.Text.Json
+
+// Single source of truth for every Utf8JsonWriter the sink creates.
+//
+// The default Utf8JsonWriter encoder is HTML-safe and renders every '"', '<', '>', '&', '\'' and
+// all non-ASCII as \uXXXX, which makes the stored Loki log line unreadable. The relaxed encoder
+// escapes the JSON-mandatory set (quote, backslash, control chars) plus the line/paragraph
+// separators U+2028/U+2029 and DEL, and emits printable non-ASCII verbatim. Output stays valid
+// JSON (and valid UTF-8), so consumers are unaffected.
+//
+// Centralised behind createWriter so escaping cannot drift between writer sites: a writer built
+// the default way (`new Utf8JsonWriter(buffer)`) would silently re-introduce \uXXXX over part of
+// the payload, and no compiler warning catches the missing options argument.
+[<RequireQualifiedAccess>]
+module internal JsonWriterDefaults =
+
+    let relaxedOptions =
+        JsonWriterOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
+
+    /// Creates a Utf8JsonWriter over the buffer using the relaxed (readable) encoder.
+    let createWriter (buffer: PooledByteBufferWriter) =
+        new Utf8JsonWriter(buffer :> IBufferWriter<byte>, relaxedOptions)

--- a/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.fs
@@ -11,8 +11,6 @@
 namespace Serilog.Sinks.Grafana.Loki
 
 open System
-open System.Buffers
-open System.Text.Encodings.Web
 open System.Text.Json
 open Serilog.Events
 open Serilog.Formatting
@@ -30,12 +28,6 @@ type LokiJsonTextFormatter(exceptionFormatter: ILokiExceptionFormatter, enrichTr
     static let pException = JsonEncodedText.Encode "Exception"
     static let pTraceId = JsonEncodedText.Encode "TraceId"
     static let pSpanId = JsonEncodedText.Encode "SpanId"
-
-    // Relaxed escaping keeps the body readable: only JSON-mandatory escapes, non-ASCII verbatim.
-    // The default Utf8JsonWriter encoder is HTML-safe and would \uXXXX-escape every '"', '<', '>',
-    // '&', '\'' and all non-ASCII. Output stays valid JSON, so consumers are unaffected.
-    static let relaxedWriterOptions =
-        JsonWriterOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
 
     // Names that collide with top-level JSON keys; prefixed with '_' when seen as properties.
     static let reserved =
@@ -180,9 +172,7 @@ type LokiJsonTextFormatter(exceptionFormatter: ILokiExceptionFormatter, enrichTr
         use buffer = new PooledByteBufferWriter(256)
         // Throwaway writer + scratch for the message render. The internal sink path passes reused
         // instances instead; the public path stays allocation-light but fully thread-safe.
-        use jsonWriter =
-            new Utf8JsonWriter(buffer :> IBufferWriter<byte>, relaxedWriterOptions)
-
+        use jsonWriter = JsonWriterDefaults.createWriter buffer
         use messageBuffer = new PooledByteBufferWriter(128)
         use messageWriter = new Utf8TextWriter(messageBuffer)
         self.FormatToBuffer(logEvent, jsonWriter, messageWriter)

--- a/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/LokiJsonTextFormatter.fs
@@ -12,6 +12,7 @@ namespace Serilog.Sinks.Grafana.Loki
 
 open System
 open System.Buffers
+open System.Text.Encodings.Web
 open System.Text.Json
 open Serilog.Events
 open Serilog.Formatting
@@ -29,6 +30,12 @@ type LokiJsonTextFormatter(exceptionFormatter: ILokiExceptionFormatter, enrichTr
     static let pException = JsonEncodedText.Encode "Exception"
     static let pTraceId = JsonEncodedText.Encode "TraceId"
     static let pSpanId = JsonEncodedText.Encode "SpanId"
+
+    // Relaxed escaping keeps the body readable: only JSON-mandatory escapes, non-ASCII verbatim.
+    // The default Utf8JsonWriter encoder is HTML-safe and would \uXXXX-escape every '"', '<', '>',
+    // '&', '\'' and all non-ASCII. Output stays valid JSON, so consumers are unaffected.
+    static let relaxedWriterOptions =
+        JsonWriterOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
 
     // Names that collide with top-level JSON keys; prefixed with '_' when seen as properties.
     static let reserved =
@@ -173,7 +180,9 @@ type LokiJsonTextFormatter(exceptionFormatter: ILokiExceptionFormatter, enrichTr
         use buffer = new PooledByteBufferWriter(256)
         // Throwaway writer + scratch for the message render. The internal sink path passes reused
         // instances instead; the public path stays allocation-light but fully thread-safe.
-        use jsonWriter = new Utf8JsonWriter(buffer :> IBufferWriter<byte>)
+        use jsonWriter =
+            new Utf8JsonWriter(buffer :> IBufferWriter<byte>, relaxedWriterOptions)
+
         use messageBuffer = new PooledByteBufferWriter(128)
         use messageWriter = new Utf8TextWriter(messageBuffer)
         self.FormatToBuffer(logEvent, jsonWriter, messageWriter)

--- a/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
@@ -16,21 +16,11 @@ open System
 open System.Buffers
 open System.Buffers.Text
 open System.Collections.Generic
-open System.Text.Encodings.Web
 open System.Text.Json
 open Microsoft.FSharp.NativeInterop
 open Serilog.Events
 open Serilog.Formatting
 open Serilog.Sinks.Grafana.Loki.Infrastructure
-
-/// Relaxed JSON escaping for the bytes the sink emits. The default Utf8JsonWriter encoder is
-/// HTML-safe and renders every '"', '<', '>', '&', '\'' and all non-ASCII as \uXXXX, which makes
-/// the stored log line unreadable; the relaxed encoder escapes only what JSON mandates and emits
-/// non-ASCII verbatim. Output stays valid JSON (and valid UTF-8), so consumers are unaffected.
-[<AutoOpen>]
-module private JsonWriterDefaults =
-    let relaxedWriterOptions =
-        JsonWriterOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
 
 /// Reusable per-sink serialization scratch: the buffers and writers reused across every batch
 /// (cleared/reset between uses), bundled so the serializer takes one value instead of several
@@ -41,9 +31,7 @@ type internal SerializationBuffers() =
     let body = new PooledByteBufferWriter(256)
     let message = new PooledByteBufferWriter(256)
 
-    let bodyWriter =
-        new Utf8JsonWriter(body :> IBufferWriter<byte>, relaxedWriterOptions)
-
+    let bodyWriter = JsonWriterDefaults.createWriter body
     let messageWriter = new Utf8TextWriter(message)
 
     /// Envelope buffer holding the full push payload; read by LokiPushContent after serialize.
@@ -100,8 +88,7 @@ module internal Serialization =
             | :? LokiJsonTextFormatter as fmt when fmt.GetType() = typeof<LokiJsonTextFormatter> -> fmt
             | _ -> Unchecked.defaultof<LokiJsonTextFormatter>
 
-        use jsonWriter =
-            new Utf8JsonWriter(buffers.Main :> IBufferWriter<byte>, relaxedWriterOptions)
+        use jsonWriter = JsonWriterDefaults.createWriter buffers.Main
 
         // Reused stack scratch for the per-event Unix-nanosecond timestamp. Hoisted out of
         // the event loop so the localloc happens once per batch, not once per event. An

--- a/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
@@ -16,11 +16,21 @@ open System
 open System.Buffers
 open System.Buffers.Text
 open System.Collections.Generic
+open System.Text.Encodings.Web
 open System.Text.Json
 open Microsoft.FSharp.NativeInterop
 open Serilog.Events
 open Serilog.Formatting
 open Serilog.Sinks.Grafana.Loki.Infrastructure
+
+/// Relaxed JSON escaping for the bytes the sink emits. The default Utf8JsonWriter encoder is
+/// HTML-safe and renders every '"', '<', '>', '&', '\'' and all non-ASCII as \uXXXX, which makes
+/// the stored log line unreadable; the relaxed encoder escapes only what JSON mandates and emits
+/// non-ASCII verbatim. Output stays valid JSON (and valid UTF-8), so consumers are unaffected.
+[<AutoOpen>]
+module private JsonWriterDefaults =
+    let relaxedWriterOptions =
+        JsonWriterOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)
 
 /// Reusable per-sink serialization scratch: the buffers and writers reused across every batch
 /// (cleared/reset between uses), bundled so the serializer takes one value instead of several
@@ -30,7 +40,10 @@ type internal SerializationBuffers() =
     let main = new PooledByteBufferWriter(4096)
     let body = new PooledByteBufferWriter(256)
     let message = new PooledByteBufferWriter(256)
-    let bodyWriter = new Utf8JsonWriter(body :> IBufferWriter<byte>)
+
+    let bodyWriter =
+        new Utf8JsonWriter(body :> IBufferWriter<byte>, relaxedWriterOptions)
+
     let messageWriter = new Utf8TextWriter(message)
 
     /// Envelope buffer holding the full push payload; read by LokiPushContent after serialize.
@@ -87,7 +100,8 @@ module internal Serialization =
             | :? LokiJsonTextFormatter as fmt when fmt.GetType() = typeof<LokiJsonTextFormatter> -> fmt
             | _ -> Unchecked.defaultof<LokiJsonTextFormatter>
 
-        use jsonWriter = new Utf8JsonWriter(buffers.Main :> IBufferWriter<byte>)
+        use jsonWriter =
+            new Utf8JsonWriter(buffers.Main :> IBufferWriter<byte>, relaxedWriterOptions)
 
         // Reused stack scratch for the per-event Unix-nanosecond timestamp. Hoisted out of
         // the event loop so the localloc happens once per batch, not once per event. An

--- a/src/Serilog.Sinks.Grafana.Loki/Serilog.Sinks.Grafana.Loki.fsproj
+++ b/src/Serilog.Sinks.Grafana.Loki/Serilog.Sinks.Grafana.Loki.fsproj
@@ -48,6 +48,7 @@
         <!-- Infrastructure (no Serilog dependency) -->
         <Compile Include="Infrastructure\PooledByteBufferWriter.fs"/>
         <Compile Include="Infrastructure\Utf8TextWriter.fs"/>
+        <Compile Include="Infrastructure\JsonWriterDefaults.fs"/>
 
         <!-- Public contract types -->
         <Compile Include="LokiLabel.fs"/>

--- a/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
+++ b/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
@@ -253,6 +253,19 @@ let ``body: contains Message and MessageTemplate`` () : Task =
     }
 
 [<Fact>]
+let ``body: quotes, markup and non-ASCII are not unicode-escaped`` () : Task =
+    task {
+        let handler, sink = makeSink id
+        use _ = sink
+        do! flush sink [ mkInfo [ "Note", box "a>b <c> & \"q\" Привет" ] ]
+        let raw = handler.LastBodyText
+        // Relaxed escaping emits '<' '>' '&' and non-ASCII verbatim; the default HTML-safe encoder
+        // would render them as \uXXXX, so these literal substrings could not appear in the payload.
+        test <@ raw.Contains("a>b <c> &") @>
+        test <@ raw.Contains("Привет") @>
+    }
+
+[<Fact>]
 let ``body: reserved property "Message" sanitized to "_Message"`` () : Task =
     task {
         let handler, sink = makeSink id

--- a/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
+++ b/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
@@ -257,15 +257,51 @@ let ``body: quotes, markup and non-ASCII are not unicode-escaped`` () : Task =
     task {
         let handler, sink = makeSink id
         use _ = sink
-        do! flush sink [ mkInfo [ "Note", box "a>b <c> & \"q\" Привет" ] ]
+        do! flush sink [ mkInfo [ "Note", box "a>b <c> & \"q\" café 日本語" ] ]
         use doc = handler.LastBodyJson
         let body = bodyStringOf (streamAt 0 doc) 0
         // Relaxed escaping: '<' '>' '&' and non-ASCII stay verbatim and quotes use the JSON-standard
         // \", never \uXXXX. The default HTML-safe encoder would render all of these as \uXXXX.
         test <@ body.Contains("a>b <c> &") @>
-        test <@ body.Contains("Привет") @>
+        test <@ body.Contains("café 日本語") @>
         test <@ body.Contains("\\\"q\\\"") @>
         test <@ not (body.Contains("\\u0022")) @>
+    }
+
+[<Fact>]
+let ``body: public Format path keeps quotes, markup and non-ASCII readable`` () =
+    // The sink fast path calls FormatToBuffer directly; this is the only coverage of the public
+    // ITextFormatter.Format entry point, whose Utf8JsonWriter is a separate construction site.
+    let formatter = LokiJsonTextFormatter() :> ITextFormatter
+    let event = mkInfo [ "Note", box "a>b <c> & \"q\" café 日本語" ]
+    use output = new System.IO.StringWriter()
+    formatter.Format(event, output)
+    let body = output.ToString()
+    use _ = JsonDocument.Parse(body) // output must stay valid JSON
+    test <@ body.Contains("a>b <c> &") @>
+    test <@ body.Contains("café 日本語") @>
+    test <@ body.Contains("\\\"q\\\"") @>
+    test <@ not (body.Contains("\\u")) @>
+
+[<Fact>]
+let ``labels: promoted label value keeps markup and non-ASCII verbatim`` () : Task =
+    task {
+        let handler, sink =
+            makeSink (fun o ->
+                { o with
+                    PropertiesAsLabels = [| "app" |]
+                })
+
+        use _ = sink
+        do! flush sink [ mkInfo [ "app", box "<svc> café 日本語" ] ]
+        use doc = handler.LastBodyJson
+        let raw = handler.LastBodyText
+        // The envelope writer escapes label keys/values too. The round-trip proves the label
+        // decodes back to the original; the raw scan proves it ships verbatim, not \uXXXX (a
+        // label-only regression would still decode correctly but leak escaped < or non-ASCII bytes).
+        test <@ labelOf "app" (streamAt 0 doc) = Some "<svc> café 日本語" @>
+        test <@ raw.Contains("<svc> café 日本語") @>
+        test <@ not (raw.Contains("\\u")) @>
     }
 
 [<Fact>]

--- a/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
+++ b/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
@@ -258,11 +258,14 @@ let ``body: quotes, markup and non-ASCII are not unicode-escaped`` () : Task =
         let handler, sink = makeSink id
         use _ = sink
         do! flush sink [ mkInfo [ "Note", box "a>b <c> & \"q\" Привет" ] ]
-        let raw = handler.LastBodyText
-        // Relaxed escaping emits '<' '>' '&' and non-ASCII verbatim; the default HTML-safe encoder
-        // would render them as \uXXXX, so these literal substrings could not appear in the payload.
-        test <@ raw.Contains("a>b <c> &") @>
-        test <@ raw.Contains("Привет") @>
+        use doc = handler.LastBodyJson
+        let body = bodyStringOf (streamAt 0 doc) 0
+        // Relaxed escaping: '<' '>' '&' and non-ASCII stay verbatim and quotes use the JSON-standard
+        // \", never \uXXXX. The default HTML-safe encoder would render all of these as \uXXXX.
+        test <@ body.Contains("a>b <c> &") @>
+        test <@ body.Contains("Привет") @>
+        test <@ body.Contains("\\\"q\\\"") @>
+        test <@ not (body.Contains("\\u0022")) @>
     }
 
 [<Fact>]


### PR DESCRIPTION
Fixes #339.

### Problem

The body formatter (`LokiJsonTextFormatter`) and the batch serializer build their `Utf8JsonWriter`s with no options, so they use `System.Text.Json`'s default HTML-safe `JavaScriptEncoder`. It escapes `"`, `'`, `<`, `>`, `&` and all non-ASCII as `\uXXXX`. Because Serilog quotes string property values by default, this makes most stored Loki lines unreadable — a regression from v8.x, which used Serilog's `JsonValueFormatter` (standard escaping). See #339 for details.

### Fix

Construct the writers with `JsonWriterOptions(Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping)`, applied at all three writer sites (formatter body, batch envelope, reused body buffer) via a shared value.

Before:

```
{"Message":"Initialize \u0022SAGO\u0022", ...}
```

After:

```
{"Message":"Initialize \"SAGO\"", ...}
```

### Notes

- Output stays valid JSON and valid UTF-8, so consumers (including `| json` queries) are unaffected. "Unsafe" in the encoder name only refers to embedding JSON directly into HTML, which does not apply to Loki log bodies.
- Added a unit test asserting `<`, `>`, `&` and non-ASCII survive verbatim.
- `dotnet test` (UnitTests, net10.0): 122/122 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Loki JSON formatting so quotes, markup characters, and non-ASCII text (e.g., Cyrillic) remain readable instead of being converted to escaped/unicode forms, while still producing valid JSON.
  * Ensured the same improved escaping behavior is applied consistently across log event serialization and the public formatter output.
* **Tests**
  * Added unit tests covering the public formatter path and promoted labels, verifying markup/non-ASCII remain verbatim and that quote escaping follows standard JSON rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->