### PR TITLE
Trim trailing newline from formatted entry bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,13 @@ override `Format` or `SanitizePropertyName`, then pass it via `textFormatter`:
 }
 ```
 
+**Trailing newlines.** Any trailing `\r` / `\n` a formatter leaves is stripped before the body is written — always, and
+not configurable. A Loki entry is a JSON string value, so unlike Console or File — where that newline separates records
+in the stream — it would otherwise be stored as content and show up as a blank line in Grafana. This matters for output
+templates: both `{NewLine}` and `{Exception}` render one, so a template ending in `{Exception}` produces a trailing
+newline whenever an event carries an exception. Newlines *inside* a body are preserved; a body that deliberately ends in
+one loses it. This matches v8.
+
 **Custom exception formatter.** Exception serialization is delegated to `ILokiExceptionFormatter`. The default
 (`LokiExceptionFormatter`) recursively writes `Type`, `Message`, `Source`, `StackTrace` and inner exceptions. Replace it
 to scrub PII, change the shape, or suppress stack traces:

--- a/src/Serilog.Sinks.Grafana.Loki/Infrastructure/Utf8TextWriter.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/Infrastructure/Utf8TextWriter.fs
@@ -70,8 +70,10 @@ type internal Utf8TextWriter(bufferWriter: PooledByteBufferWriter) =
             let written = Encoding.UTF8.GetBytes(value, span)
             writer.Advance(written)
 
-    // Serilog formatters end log lines with WriteLine(); route through Write so
-    // the newline is encoded into the same pooled buffer rather than flushed.
+    // Some formatters terminate a line with WriteLine() (CompactJsonFormatter does; the
+    // output-template formatters instead Write() Environment.NewLine themselves). Route it
+    // through Write so the newline lands in the same pooled buffer rather than being flushed.
+    // Whichever way it arrives, Serialization strips it from the tail of a Loki entry body.
     override self.WriteLine(value: string) =
         self.Write(value)
         self.Write('\n')

--- a/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
@@ -60,6 +60,10 @@ module internal Serialization =
     let private jStream = JsonEncodedText.Encode "stream"
     let private jValues = JsonEncodedText.Encode "values"
 
+    /// Trailing bytes stripped from a formatted body. Bound once: an inline "\r\n"B literal
+    /// allocates a fresh array on every evaluation, which in the per-event loop is a regression.
+    let private lineFraming = "\r\n"B
+
     /// Serializes a complete batch of log events into mainBuffer as a Loki push payload:
     ///
     ///   { "streams": [ { "stream": { labels }, "values": [ [ "ts_ns", "body", { meta }? ], ... ] } ] }
@@ -133,7 +137,12 @@ module internal Serialization =
                     use textWriter = new Utf8TextWriter(buffers.Body)
                     textFormatter.Format(event, textWriter)
 
-                jsonWriter.WriteStringValue(buffers.Body.WrittenSpan)
+                // A formatter terminates the body the way a stream sink needs — Serilog's stock
+                // output templates render a trailing newline via {NewLine} or {Exception}. That is
+                // record framing, load-bearing for Console/File but not here: a Loki entry is a JSON
+                // string value framed by the payload itself, so a newline left in place is stored as
+                // content and renders as a blank line in Grafana (#347). Interior newlines survive.
+                jsonWriter.WriteStringValue(buffers.Body.WrittenSpan.TrimEnd(ReadOnlySpan<byte>(lineFraming)))
                 buffers.Body.Clear()
 
                 // Optional 3rd element: per-line structured metadata, written straight to the

--- a/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
+++ b/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
@@ -2,6 +2,7 @@ module Serilog.Sinks.Grafana.Loki.Tests.WireFormatTests
 
 open System
 open System.Diagnostics
+open System.Globalization
 open System.Net
 open System.Net.Http
 open System.Text
@@ -12,6 +13,7 @@ open Swensen.Unquote
 open Xunit
 open Serilog.Events
 open Serilog.Formatting
+open Serilog.Formatting.Display
 open Serilog.Parsing
 open Serilog.Core
 open Serilog.Sinks.Grafana.Loki
@@ -146,6 +148,17 @@ let private timestampOf (stream: JsonElement) (i: int) =
 let private bodyStringOf (stream: JsonElement) (i: int) =
     let entry = stream.GetProperty("values")[i]
     entry[1].GetString()
+
+/// Serializes a single event through the given formatter and returns the entry body.
+let private bodyFrom (formatter: ITextFormatter) (event: LogEvent) =
+    task {
+        let handler, sink = makeSink (fun o -> { o with TextFormatter = formatter })
+
+        use _ = sink
+        do! flush sink [ event ]
+        use doc = handler.LastBodyJson
+        return bodyStringOf (streamAt 0 doc) 0
+    }
 
 let private bodyProp (key: string) (stream: JsonElement) (i: int) =
     use body = JsonDocument.Parse(bodyStringOf stream i)
@@ -990,22 +1003,170 @@ type private FixedBodyFormatter(text: string) =
     interface ITextFormatter with
         member _.Format(_, output) = output.Write(text)
 
+/// Terminates each line with TextWriter.WriteLine rather than an embedded newline.
+type private WriteLineFormatter() =
+    interface ITextFormatter with
+        member _.Format(_, output) =
+            output.WriteLine("first")
+            output.WriteLine("last")
+
+/// Renders the event's `Body` property verbatim, so events in one batch can differ.
+type private BodyPropertyFormatter() =
+    interface ITextFormatter with
+        member _.Format(logEvent, output) =
+            match logEvent.Properties.TryGetValue "Body" with
+            | true, (:? ScalarValue as v) -> output.Write(string v.Value)
+            | _ -> ()
+
 [<Fact>]
 let ``body: custom ITextFormatter goes through Utf8TextWriter path`` () : Task =
     // When a non-LokiJsonTextFormatter is used, Serialization.fs routes through
     // Utf8TextWriter. Verify the custom body survives unchanged in the Loki payload.
     task {
+        let! body = bodyFrom (FixedBodyFormatter("CUSTOM_BODY")) (mkInfo [])
+        test <@ body = "CUSTOM_BODY" @>
+    }
+
+// ── trailing newline trimming (#347) ──────────────────────────────────────────
+
+// A fixed timestamp with an explicit offset makes MessageTemplateTextFormatter's rendering
+// deterministic ({Timestamp} formats the DateTimeOffset as-is, without zone conversion), so
+// these tests can assert on the exact body rather than a suffix.
+let private fixedTs = DateTimeOffset(2026, 8, 8, 10, 30, 15, TimeSpan.Zero)
+
+/// The stock Console/File output template, rendered under the invariant culture so the
+/// exact-body assertions do not depend on the CI agent's locale. #347 reports the same shape
+/// with plain `{Message}`; only the message rendering differs, not the trailing newline.
+let private stockFormatter =
+    MessageTemplateTextFormatter(
+        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+        CultureInfo.InvariantCulture
+    )
+
+let private mkRendered (ex: exn) =
+    LogEvent(
+        fixedTs,
+        LogEventLevel.Information,
+        ex,
+        traceParser.Parse("Hello {Name}"),
+        [ LogEventProperty("Name", ScalarValue("world")) ]
+    )
+
+[<Fact>]
+let ``body: stock output template leaves no trailing newline`` () : Task =
+    // {NewLine} terminates the rendered line. That is record framing for Console/File,
+    // but a Loki entry is a JSON string value, so it must not survive into the payload.
+    task {
+        let! body = bodyFrom stockFormatter (mkRendered null)
+        test <@ body = "[10:30:15 INF] Hello world" @>
+    }
+
+[<Fact>]
+let ``body: rendered exception leaves no trailing newline`` () : Task =
+    // {Exception} renders as Exception.ToString() + Environment.NewLine, so a template ending
+    // in {Exception} still emits a trailing newline — dropping {NewLine} is not a workaround.
+    task {
+        let ex = InvalidOperationException("boom")
+        let! body = bodyFrom stockFormatter (mkRendered ex)
+
+        let expected =
+            $"[10:30:15 INF] Hello world{Environment.NewLine}System.InvalidOperationException: boom"
+
+        test <@ body = expected @>
+    }
+
+[<Theory>]
+[<InlineData("first\r\nsecond\nthird\r\n", "first\r\nsecond\nthird")>] // interior newlines survive
+[<InlineData("line\n\r\n\n", "line")>] // a whole trailing run goes, not just the last byte
+[<InlineData("line\r", "line")>] // lone CR, not preceded by an LF
+[<InlineData("café 日本語\r\n", "café 日本語")>] // UTF-8 continuations (0x80-0xBF) never look like CR/LF
+[<InlineData("padded \t", "padded \t")>] // spaces and tabs are content, not framing (matches v8)
+[<InlineData("\r\n\r\n", "")>] // a body that is entirely framing trims to empty
+let ``body: only trailing CR and LF are trimmed from a formatted body`` (rendered: string) (expected: string) : Task =
+    task {
+        let! body = bodyFrom (FixedBodyFormatter(rendered)) (mkInfo [])
+        test <@ body = expected @>
+    }
+
+[<Fact>]
+let ``body: a formatter terminating via WriteLine is trimmed`` () : Task =
+    // Utf8TextWriter.WriteLine is its own code path (it appends '\n' rather than
+    // Environment.NewLine), and it is how CompactJsonFormatter ends its output.
+    task {
+        let! body = bodyFrom (WriteLineFormatter()) (mkInfo [])
+        test <@ body = "first\nlast" @>
+    }
+
+[<Fact>]
+let ``body: trimming is per entry across a batch and leaves no stale bytes`` () : Task =
+    // The body buffer is reused for every event in a batch. Trimming must not shorten what
+    // gets cleared, or a long body's tail would bleed into the next, shorter entry.
+    task {
         let handler, sink =
             makeSink (fun o ->
                 { o with
-                    TextFormatter = FixedBodyFormatter("CUSTOM_BODY")
+                    TextFormatter = BodyPropertyFormatter()
                 })
 
         use _ = sink
-        do! flush sink [ mkInfo [] ]
+
+        // Rendered → expected, so the two sides can never drift apart.
+        let cases =
+            [
+                "a long first body that ends in a newline\r\n", "a long first body that ends in a newline"
+                "short", "short"
+                "third\n", "third"
+                "d", "d"
+            ]
+
+        let events =
+            cases
+            |> List.mapi (fun i (rendered, _) ->
+                mkEventAt (fixedTs.AddSeconds(float i)) LogEventLevel.Information [ "Body", box rendered ])
+
+        do! flush sink events
         use doc = handler.LastBodyJson
-        let body = bodyStringOf (streamAt 0 doc) 0
-        test <@ body = "CUSTOM_BODY" @>
+        let s = streamAt 0 doc
+        let actual = List.init cases.Length (bodyStringOf s)
+
+        test <@ actual = List.map snd cases @>
+    }
+
+[<Fact>]
+let ``body: a trimmed body still carries structured metadata`` () : Task =
+    // The trimmed WriteStringValue hands the writer straight to the metadata element;
+    // a shortened body must not disturb the optional 3rd entry element.
+    task {
+        let handler, sink =
+            makeSink (fun o ->
+                { o with
+                    TextFormatter = FixedBodyFormatter("meta body\r\n")
+                    PropertiesAsStructuredMetadata = [| "RequestId" |]
+                })
+
+        use _ = sink
+        do! flush sink [ mkInfo [ "RequestId", box "req-42" ] ]
+        use doc = handler.LastBodyJson
+        let s = streamAt 0 doc
+        test <@ bodyStringOf s 0 = "meta body" @>
+        test <@ entryElementCount s 0 = 3 @>
+        test <@ metadataProp "RequestId" s 0 = Some "req-42" @>
+    }
+
+[<Fact>]
+let ``body: built-in formatter output is unaffected by trimming`` () : Task =
+    // The default path emits JSON closing on '}', so the trim finds nothing to strip and the
+    // payload stays byte-identical — properties included, not just the final character.
+    task {
+        let handler, sink = makeSink id
+        use _ = sink
+        do! flush sink [ mkInfo [ "Note", box "value" ] ]
+        use doc = handler.LastBodyJson
+        let s = streamAt 0 doc
+        let body = bodyStringOf s 0
+        // bodyProp parses the body, so it also asserts the payload is still valid JSON.
+        test <@ body.EndsWith("}") @>
+        test <@ bodyProp "Note" s 0 = Some "value" @>
     }
 
 // ── HTTP error response path ──────────────────────────────────────────────────

--- a/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
+++ b/tests/Serilog.Sinks.Grafana.Loki.UnitTests/WireFormatTests.fs
@@ -1154,19 +1154,21 @@ let ``body: a trimmed body still carries structured metadata`` () : Task =
     }
 
 [<Fact>]
-let ``body: built-in formatter output is unaffected by trimming`` () : Task =
-    // The default path emits JSON closing on '}', so the trim finds nothing to strip and the
-    // payload stays byte-identical — properties included, not just the final character.
+let ``body: built-in formatter output is byte-identical under trimming`` () : Task =
+    // The default path emits JSON closing on '}', so the trim finds nothing to strip. Asserting
+    // the whole payload rather than parsed fragments is what actually pins that: escaping,
+    // property order and envelope shape all have to survive, not just the final character.
+    // fixedTs makes the nanosecond timestamp deterministic.
     task {
         let handler, sink = makeSink id
         use _ = sink
-        do! flush sink [ mkInfo [ "Note", box "value" ] ]
-        use doc = handler.LastBodyJson
-        let s = streamAt 0 doc
-        let body = bodyStringOf s 0
-        // bodyProp parses the body, so it also asserts the payload is still valid JSON.
-        test <@ body.EndsWith("}") @>
-        test <@ bodyProp "Note" s 0 = Some "value" @>
+        do! flush sink [ mkEventAt fixedTs LogEventLevel.Information [ "Note", box "value" ] ]
+
+        // Triple-quoted: the body is a JSON string value, so its own quotes arrive escaped.
+        let expected =
+            """{"streams":[{"stream":{"level":"info"},"values":[["1786185015000000000","{\"Message\":\"\",\"MessageTemplate\":\"\",\"Note\":\"value\"}"]]}]}"""
+
+        test <@ handler.LastBodyText = expected @>
     }
 
 // ── HTTP error response path ──────────────────────────────────────────────────


### PR DESCRIPTION
﻿Fixes #347.

## What happens

A custom `ITextFormatter` leaves a trailing newline on the rendered body, and v9 writes it into the Loki entry verbatim. Reproduced against the published packages with the reporter's template:

```
v8.3.2 → ["…","[11:19:26 INF] Hello \u0022world\u0022"]
v9.0.1 → ["…","[11:18:53 INF] Hello \"world\"\r\n"]
```

Grafana renders that stored newline as a blank line after every entry.

## Why it is a bug and not a formatter's business

A formatter terminates the body the way a *stream* sink needs it: Console and File concatenate formatter output onto a stream, so the trailing newline is the record separator and the formatter rightly owns it. Serilog's stock output templates render one via `{NewLine}`, and `{Exception}` renders as `Exception.ToString() + Environment.NewLine`.

A Loki entry is not a line in a stream — it is a JSON string value at `values[i][1]`, framed by the payload itself. There the newline is not framing, it is content.

The rest of the ecosystem agrees, and solves it by parameterising the formatter, which is not available to us:

- **Seq** concatenates formatter output with no separator of its own and *depends* on the trailing newline (`ConstrainedBufferedFormatter` even subtracts `NewLineByteCount` when checking size limits). Its own formatter exposes `Format` (with newline) and `FormatEvent` (without).
- **Elasticsearch** passes `closingDelimiter: string.Empty` for the bulk path and `Environment.NewLine` for the durable file path — one formatter, two destinations.

Both only control their *own* default formatter. This sink accepts an arbitrary user-supplied `ITextFormatter` it cannot configure, so the single point where bytes cross into `values[i][1]` is the right boundary.

v8 trimmed exactly here (`LokiBatchFormatter.GenerateEntry`, `TrimEnd('\r', '\n')`) for eight major versions; the V9 rewrite dropped it. This restores parity.

## There is no template-side workaround

`{Exception}` appends a newline whenever an event carries an exception, regardless of the template:

```
"[{Level:u3}] {Message:lj}"               → "[INF] Hello world"                       ok
"[{Level:u3}] {Message:lj} {Exception}"   → "[ERR] Failed save System…: boom\r\n"      still ends in a newline
```

So users cannot fix this by editing their template.

## The change

`Serialization.fs` trims trailing CR/LF off the body span via `MemoryExtensions.TrimEnd` before `WriteStringValue`. Allocation-free (the trim set is a module-level `"\r\n"B` binding — an inline literal would allocate ~104 bytes per event). Applied unconditionally: the built-in `LokiJsonTextFormatter` closes on `}`, so it is a proven no-op there and default output stays byte-identical, and a single exit point avoids encoding an unenforced invariant about the built-in formatter into the serializer.

Interior newlines are preserved. Trailing whitespace that is not CR/LF is preserved.

Also corrected a comment in `Utf8TextWriter` that claimed Serilog formatters always terminate via `WriteLine()` — the output-template formatters write `Environment.NewLine` through `Write` instead, which is why a writer-level fix would have missed this bug.

## Verification

- 12 new wire-format assertions; **10 of them fail** against `master`'s serializer, all 136 pass with the fix, on net8.0/net9.0/net10.0.
- Covers: the stock template, the rendered-exception case, interior newlines, a whole trailing run, a lone CR, non-ASCII bodies (UTF-8 continuation bytes can never look like CR/LF), non-CR/LF trailing whitespace, an all-framing body, a `WriteLine`-terminating formatter (the `CompactJsonFormatter` shape), structured metadata alongside a trimmed body, and per-entry trimming across a batch so a long body's tail cannot bleed into the next entry through the reused pooled buffer.
- End-to-end against the built assembly with the reporter's exact template: trailing newline gone, interior newline intact.
- `dotnet fantomas --check` clean; solution builds warning-free.

## Follow-up, not in this PR

`Serialization.fs` allocates a `Utf8TextWriter` per event inside the batch loop on the custom-formatter path, while `SerializationBuffers` already caches one for the built-in path. Pre-existing, and invisible to CI because no benchmark exercises a custom formatter. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trailing carriage returns and line feeds are now removed from serialized log bodies.
  * Internal newlines, whitespace, UTF-8 content, and structured metadata remain preserved.
  * Formatter output now produces consistent Loki entry bodies across individual and batched logs.
  * Built-in JSON output remains unchanged.

* **Documentation**
  * Clarified newline handling for compact JSON and output-template formatters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->