### PR TITLE
Reuse one Utf8TextWriter for custom formatter bodies

### DIFF
--- a/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
+++ b/src/Serilog.Sinks.Grafana.Loki/Serialization.fs
@@ -33,6 +33,7 @@ type internal SerializationBuffers() =
 
     let bodyWriter = JsonWriterDefaults.createWriter body
     let messageWriter = new Utf8TextWriter(message)
+    let bodyTextWriter = new Utf8TextWriter(body)
 
     /// Envelope buffer holding the full push payload; read by LokiPushContent after serialize.
     member _.Main = main
@@ -42,11 +43,16 @@ type internal SerializationBuffers() =
     member _.BodyWriter = bodyWriter
     /// Reused writer for rendering each event's message to UTF-8.
     member _.MessageWriter = messageWriter
+    /// Reused TextWriter over the body buffer, handed to a custom ITextFormatter.
+    /// Utf8TextWriter holds no state of its own, so clearing Body between events is
+    /// the only reset needed — see the custom-formatter branch in serialize.
+    member _.BodyTextWriter = bodyTextWriter
 
     interface IDisposable with
         member _.Dispose() =
             (bodyWriter :> IDisposable).Dispose()
             (messageWriter :> IDisposable).Dispose()
+            (bodyTextWriter :> IDisposable).Dispose()
             (main :> IDisposable).Dispose()
             (body :> IDisposable).Dispose()
             (message :> IDisposable).Dispose()
@@ -131,11 +137,12 @@ module internal Serialization =
                 // Body: built-in fast path writes JSON straight to bodyBuffer (via the reused
                 // writer); a custom ITextFormatter writes text through Utf8TextWriter. Either way
                 // bodyBuffer then holds the UTF-8 body, which becomes the 2nd "values" element.
+                // Both writers are owned by buffers and reused across the batch — Utf8TextWriter
+                // carries no state, so clearing bodyBuffer below is the whole reset.
                 if not (obj.ReferenceEquals(builtIn, null)) then
                     builtIn.FormatToBuffer(event, buffers.BodyWriter, buffers.MessageWriter)
                 else
-                    use textWriter = new Utf8TextWriter(buffers.Body)
-                    textFormatter.Format(event, textWriter)
+                    textFormatter.Format(event, buffers.BodyTextWriter)
 
                 // A formatter terminates the body the way a stream sink needs — Serilog's stock
                 // output templates render a trailing newline via {NewLine} or {Exception}. That is


### PR DESCRIPTION
Second half of #349, now that #350 has landed. Diff is a single file.

### Change

`Serialization.serialize` allocated a `Utf8TextWriter` per event, inside the batch loop, on the custom-`ITextFormatter` path:

```fsharp
use textWriter = new Utf8TextWriter(buffers.Body)   // one per event
textFormatter.Format(event, textWriter)
```

`SerializationBuffers` already caches the equivalent writer for the message buffer (`MessageWriter`); this adds the symmetric `BodyTextWriter` over the body buffer, and the call site becomes `textFormatter.Format(event, buffers.BodyTextWriter)`.

### Why it is safe

- `Utf8TextWriter` holds no state beyond its backing buffer — every `Write` encodes straight into the pooled buffer, there is no internal buffering (its own doc comment says so, which is why `WrittenSpan` is valid without a `Flush`).
- That buffer is already cleared per event by the existing `buffers.Body.Clear()`, which is the whole reset.
- `SerializationBuffers` is sink-owned and used serially — the same guarantee `MessageWriter` has relied on since the V9 rewrite.
- Dropping `use` costs nothing: `Utf8TextWriter` does not override `Dispose`, so a formatter that squirrelled away the reference is exactly as (un)protected as it is today.

### Measured

Isolated effect of this change, measured locally against `master` using `CustomFormatterSinkBenchmarks.Push(EventCount: 1000)` (added in #350):

| Payload | before | after | Δ |
|---|--:|--:|--:|
| Simple | 116.03 KB | 69.37 KB | **−40.2%** |
| Exception | 7573.80 KB | 7519.11 KB | −0.7% |

The Simple saving is 46.66 KB against 46.9 KB predicted (48 bytes × 1000 events). Exception is dominated by exception rendering, so the same absolute saving barely registers.

The CI comparison table reports **−54.0%** on the Simple row. That is against published **9.0.1**, which lacks both this change and the newline trim from #348, so it bundles the two — the extra ~16 KB is #348 shortening each body. −40% is this PR's own contribution.

The control worth checking: `SinkBenchmarks` Simple rows are `+0.0%` at both 1000 and 10000 events, confirming the built-in formatter path is untouched. The `+0.8%` on the Exception rows is pre-existing master-vs-9.0.1 drift from #340, identical on both row sizes and unrelated to this change.

`Mean` moved too, but on shared runners it is noise — `Allocated` is the signal.

### Coverage

No new test. The batch test added in #348 (`body: trimming is per entry across a batch and leaves no stale bytes`) already drives a custom formatter across four events with differing bodies, long → short, and would fail if the reused writer carried state between them. 136/136 pass on net8.0/net9.0/net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)